### PR TITLE
Make pdfparser more friendly for programmatic use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adamjaso/pdfparser
+module github.com/KarmaPenny/pdfparser
 
 go 1.21.5
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/KarmaPenny/pdfparser
 
 go 1.21.5
 
-require (
-	github.com/KarmaPenny/pdfparser v1.1.0
-	golang.org/x/image v0.15.0
-)
+require golang.org/x/image v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/adamjaso/pdfparser
+
+go 1.21.5
+
+require (
+	github.com/KarmaPenny/pdfparser v1.1.0
+	golang.org/x/image v0.15.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/KarmaPenny/pdfparser v1.1.0 h1:OMDMZ9b66w2JY0ZP5uuGFl+VVpW9RupU80slp/+/OHA=
+github.com/KarmaPenny/pdfparser v1.1.0/go.mod h1:f8ncLLG7eAU+2nT0S2Lv2o72sKdTX8joJn7X5xreKlo=
+golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
+golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/KarmaPenny/pdfparser v1.1.0 h1:OMDMZ9b66w2JY0ZP5uuGFl+VVpW9RupU80slp/+/OHA=
-github.com/KarmaPenny/pdfparser v1.1.0/go.mod h1:f8ncLLG7eAU+2nT0S2Lv2o72sKdTX8joJn7X5xreKlo=
 golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
 golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=

--- a/main.go
+++ b/main.go
@@ -3,12 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/KarmaPenny/pdfparser/pdf"
+	"io"
 	"os"
+
+	"github.com/adamjaso/pdfparser/pdf"
 )
 
 var overwrite *bool
 var password *string
+var textonly *bool
 
 func usage() {
 	fmt.Fprintln(os.Stderr, "PDF Parser - Decrypts a PDF file and extracts contents")
@@ -21,6 +24,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  -f        overwrite output directory")
 	fmt.Fprintln(os.Stderr, "  -p        decryption password")
 	fmt.Fprintln(os.Stderr, "  -v        display verbose messages")
+	fmt.Fprintln(os.Stderr, "  -t        output the text only to standard output")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Copyright (C) 2019 Cole Robinette")
 	fmt.Fprintln(os.Stderr, "This program is free to use, redistribute, and modify under")
@@ -32,6 +36,7 @@ func usage() {
 func init() {
 	overwrite = flag.Bool("f", false, "overwrite of output directory if it already exists")
 	password = flag.String("p", "", "encryption password (default: empty)")
+	textonly = flag.Bool("t", false, "output the contents.txt only")
 	pdf.Verbose = flag.Bool("v", false, "display verbose messages")
 	flag.Usage = usage
 	flag.Parse()
@@ -42,14 +47,29 @@ func init() {
 }
 
 func main() {
-	// check if output directory already exists
-	if _, err := os.Stat(flag.Arg(1)); !os.IsNotExist(err) && !*overwrite {
-		fmt.Printf("output directory \"%s\" already exists, use -f to overwrite\n", flag.Arg(1))
-		return
-	}
+	if *textonly {
+		bo := pdf.NewBufferOutput()
+		err := pdf.ParseWithOptions(pdf.ParseOptions{
+			Filename:  flag.Arg(0),
+			Password:  *password,
+			OutputDir: flag.Arg(1),
+			Output:    bo,
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		} else {
+			_, _ = io.Copy(os.Stdout, bo.Text)
+		}
+	} else {
+		// check if output directory already exists
+		if _, err := os.Stat(flag.Arg(1)); !os.IsNotExist(err) && !*overwrite {
+			fmt.Printf("output directory \"%s\" already exists, use -f to overwrite\n", flag.Arg(1))
+			return
+		}
 
-	// parse the pdf
-	if err := pdf.Parse(flag.Arg(0), *password, flag.Arg(1)); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		// parse the pdf
+		if err := pdf.Parse(flag.Arg(0), *password, flag.Arg(1)); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/adamjaso/pdfparser/pdf"
+	"github.com/KarmaPenny/pdfparser/pdf"
 )
 
 var overwrite *bool

--- a/pdf/output.go
+++ b/pdf/output.go
@@ -1,23 +1,43 @@
 package pdf
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
 )
 
+type bufferCloser struct {
+	bytes.Buffer
+}
+
+func (*bufferCloser) Close() error { return nil }
+
 type Output struct {
-	Commands *os.File
-	Directory string
-	Errors *os.File
-	Files *os.File
-	Javascript *os.File
-	Raw *os.File
-	Text *os.File
-	URLs *os.File
+	Commands   io.ReadWriteCloser
+	Directory  string
+	Errors     io.ReadWriteCloser
+	Files      io.ReadWriteCloser
+	Javascript io.ReadWriteCloser
+	Raw        io.ReadWriteCloser
+	Text       io.ReadWriteCloser
+	URLs       io.ReadWriteCloser
+}
+
+func NewBufferOutput() (output *Output) {
+	output = &Output{}
+	output.Commands = &bufferCloser{}
+	output.Errors = &bufferCloser{}
+	output.Files = &bufferCloser{}
+	output.Javascript = &bufferCloser{}
+	output.Raw = &bufferCloser{}
+	output.Text = &bufferCloser{}
+	output.URLs = &bufferCloser{}
+	return
 }
 
 func NewOutput(directory string) (output *Output, err error) {

--- a/pdf/pdf.go
+++ b/pdf/pdf.go
@@ -5,16 +5,39 @@ import (
 	"os"
 )
 
-func Parse(file_path string, password string, output_dir string) error {
+type ParseOptions struct {
+	Filename  string
+	Password  string
+	OutputDir string
+	Output    *Output
+}
+
+func Parse(file_path, password, output_dir string) error {
+	return ParseWithOptions(ParseOptions{
+		Filename:  file_path,
+		Password:  password,
+		OutputDir: output_dir,
+	})
+}
+
+func ParseWithOptions(opts ParseOptions) error {
+	if Verbose == nil {
+		Verbose = new(bool)
+	}
 	// open the pdf
-	file, err := os.Open(file_path)
+	file, err := os.Open(opts.Filename)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
 	// create output directory and files
-	output, err := NewOutput(output_dir)
+	var output *Output
+	if opts.Output != nil {
+		output = opts.Output
+	} else {
+		output, err = NewOutput(opts.OutputDir)
+	}
 	defer output.Close()
 	if err != nil {
 		return err
@@ -25,7 +48,7 @@ func Parse(file_path string, password string, output_dir string) error {
 
 	// load the pdf
 	Debug("Loading xref")
-	if err := parser.Load(password); err != nil {
+	if err := parser.Load(opts.Password); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Make pdfparser more friendly for programmatic use

- Add ability to specify a custom `pdf.Output` type for programmatic use
- Add `NewBufferedOutput` to support in-memory only PDF parsing
- Add `-t` flag to just extract the text from a PDF without writing any files to disk
- Add `pdf.ParseOptions` to make more friendly for programmatic use
- Add go.mod dependency files
- Fix panic when calling `Parse` with nil `Verbose`